### PR TITLE
Handle null case for saml_metadata_document

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -50,7 +50,7 @@ module "ec2_client_vpn" {
   vpc_id                        = module.vpc.outputs.vpc_id
   export_client_certificate     = var.export_client_certificate
   saml_provider_arn             = var.saml_provider_arn
-  saml_metadata_document        = file(var.saml_metadata_document)
+  saml_metadata_document        = var.saml_metadata_document != null ? file(var.saml_metadata_document) : null
   dns_servers                   = var.dns_servers
   split_tunnel                  = var.split_tunnel
 


### PR DESCRIPTION
## what
* Handle null case for saml_metadata_document

## why
* There is no `saml_metadata_document` when we use `saml_provider_arn` instead 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EC2 Client VPN module now supports optional SAML metadata configuration. The module gracefully handles cases where the SAML metadata document is not provided, improving flexibility for deployments that don't require SAML authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->