### PR TITLE
make auth rules naming unique

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -16,7 +16,7 @@ locals {
 
   authorization_rules = [
     for private_subnet_cidr in module.vpc.outputs.private_subnet_cidrs : {
-      name                 = "Internal Rule"
+      name                 = "Internal Rule - ${private_subnet_cidr}"
       access_group_id      = null
       authorize_all_groups = true
       description          = "Internal authorization rule"

--- a/src/main.tf
+++ b/src/main.tf
@@ -16,7 +16,7 @@ locals {
 
   authorization_rules = [
     for private_subnet_cidr in module.vpc.outputs.private_subnet_cidrs : {
-      name                 = "Internal Rule - ${private_subnet_cidr}"
+      name                 = "internal.${private_subnet_cidr}"
       access_group_id      = null
       authorize_all_groups = true
       description          = "Internal authorization rule"


### PR DESCRIPTION
## what
* make auth rules names unique

## why
* recent update to vpn client module uses key value. getting error for dup keys

`╷
│ Error: Duplicate object key
│
│   on .terraform/modules/ec2_client_vpn/main.tf line 242, in resource "aws_ec2_client_vpn_authorization_rule" "default":
│  241:   for_each = {
│  242:     for k, v in var.authorization_rules : coalesce(lookup(v, "name", null), tostring(k)) => v if local.enabled
│  243:   }
│     ├────────────────
│     │ k is 2
│     │ v is map of string with 5 elements
│
│ Two different items produced the key "Internal Rule" in this 'for' expression. If duplicates are expected, use the ellipsis (...) after
│ the value expression to enable grouping by key.
`

## references
* https://github.com/cloudposse/terraform-aws-ec2-client-vpn/releases/tag/v2.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated authorization rule naming to include subnet identifiers for clearer, per-subnet organization and easier identification. This is a naming/organizational change only; functionality and access behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->